### PR TITLE
#26 https://github.com/atp-mipt/ljv/issues/26

### DIFF
--- a/ljv/src/main/java/org/atpfivt/ljv/GraphBuilder.java
+++ b/ljv/src/main/java/org/atpfivt/ljv/GraphBuilder.java
@@ -298,7 +298,7 @@ final class GraphBuilder {
      */
     private List<AbstractMap.SimpleEntry<Object, Boolean>> findReferences(AbstractMap.SimpleEntry<Object, Boolean> pair, List<AbstractMap.SimpleEntry<Object, Boolean>> pairs) {
         return pairs.stream()
-                .filter(p -> p.getValue() == Boolean.FALSE)
+                .filter(p -> p.getValue().equals(Boolean.FALSE))
                 .filter(p -> p.getKey() == pair.getKey())
                 .peek(p -> p.setValue(Boolean.TRUE)
                 )

--- a/ljv/src/main/java/org/atpfivt/ljv/LJV.java
+++ b/ljv/src/main/java/org/atpfivt/ljv/LJV.java
@@ -24,7 +24,8 @@ import org.atpfivt.ljv.provider.FieldAttributesProvider;
 import org.atpfivt.ljv.provider.ObjectAttributesProvider;
 import org.atpfivt.ljv.provider.impl.*;
 
-import java.lang.reflect.*;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -37,6 +38,7 @@ public final class LJV {
     private final List<ArrayElementAttributeProvider> arrayElementAttributeProviders = new ArrayList<>();
     private final Set<Object> pretendPrimitiveSet = new HashSet<>();
     private final Set<Object> ignoreSet = new HashSet<>();
+    private final List<Object> roots = new ArrayList<>();
     private Direction direction = Direction.TB;
 
     public LJV setDirection(Direction direction) {
@@ -252,6 +254,10 @@ public final class LJV {
         }
     }
 
+    public List<Object> getRoots() {
+        return roots;
+    }
+
     /**
      * Treat objects of this class as primitives; i.e., {@code toString}
      * is called on the object, and the result displayed in the label like
@@ -355,4 +361,26 @@ public final class LJV {
     public String drawGraph(Object obj) {
         return new GraphBuilder(this).generateDOT(obj);
     }
+
+    /**
+     *add an Object to {@code roots}
+     * @param  root
+     * @return this
+     */
+    public LJV addRoot(Object root){
+        if(root != null) {
+            this.roots.add(root);
+        }
+        return this;
+    }
+
+    /**
+     * roots {@code roots} references counts can be visualized
+     * @return String representation containing DOT commands to build the graph
+     */
+    public String drawGraph() {
+        return new GraphBuilder(this).generateDOT();
+    }
+
+
 }

--- a/ljv/src/test/java/org/atpfivt/ljv/LJVTest.java
+++ b/ljv/src/test/java/org/atpfivt/ljv/LJVTest.java
@@ -1,13 +1,10 @@
 package org.atpfivt.ljv;
 
 import org.approvaltests.Approvals;
-import org.atpfivt.ljv.provider.impl.NewObjectHighlighter;
 import org.junit.jupiter.api.Test;
 import org.reflections.ReflectionUtils;
 
-import java.io.IOException;
 import java.lang.reflect.Field;
-import java.net.URISyntaxException;
 import java.util.*;
 
 public class LJVTest {
@@ -103,6 +100,17 @@ public class LJVTest {
                 .addIgnoreField("count")
                 .addIgnoreField("offset")
                 .drawGraph(a);
+        Approvals.verify(actual_graph);
+    }
+
+    @Test
+    void multipleRoots() {
+        ArrayList<Object> a = new ArrayList<>();
+        Person p = new Person("Albert", Gender.MALE, 35);
+        Person p1 = p;
+        Person p2 = p;
+        Person p4 = new Person("Albert", Gender.MALE, 35);
+        String actual_graph = new LJV().addRoot(p).addRoot(p1).addRoot(p2).addRoot(p4).drawGraph();
         Approvals.verify(actual_graph);
     }
 

--- a/ljv/src/test/java/org/atpfivt/ljv/approvals/LJVTest.multipleRoots.approved.txt
+++ b/ljv/src/test/java/org/atpfivt/ljv/approvals/LJVTest.multipleRoots.approved.txt
@@ -1,0 +1,152 @@
+digraph Java {
+	rankdir="TB";
+	node[shape=plaintext]
+	n1[label=<
+		<table border='0' cellborder='1' cellspacing='0'>
+			<tr>
+				<td rowspan='2'>Person</td>
+			</tr>
+			<tr>
+				<td>age: 35</td>
+			</tr>
+		</table>
+	>];
+	n2[label=<
+		<table border='0' cellborder='1' cellspacing='0'>
+			<tr>
+				<td rowspan='3'>String</td>
+			</tr>
+			<tr>
+				<td>hash: 0</td>
+			</tr>
+			<tr>
+				<td>coder: 0</td>
+			</tr>
+		</table>
+	>];
+	n3[label=<
+		<table border='0' cellborder='1' cellspacing='0'>
+			<tr>
+				<td>65</td>
+				<td>108</td>
+				<td>98</td>
+				<td>101</td>
+				<td>114</td>
+				<td>116</td>
+			</tr>
+		</table>
+	>];
+	n2 -> n3[label="value",fontsize=12];
+	n1 -> n2[label="name",fontsize=12];
+	n4[label=<
+		<table border='0' cellborder='1' cellspacing='0'>
+			<tr>
+				<td rowspan='2'>Gender</td>
+			</tr>
+			<tr>
+				<td>ordinal: 0</td>
+			</tr>
+		</table>
+	>];
+	n5[label=<
+		<table border='0' cellborder='1' cellspacing='0'>
+			<tr>
+				<td rowspan='3'>String</td>
+			</tr>
+			<tr>
+				<td>hash: 2358797</td>
+			</tr>
+			<tr>
+				<td>coder: 0</td>
+			</tr>
+		</table>
+	>];
+	n6[label=<
+		<table border='0' cellborder='1' cellspacing='0'>
+			<tr>
+				<td>77</td>
+				<td>65</td>
+				<td>76</td>
+				<td>69</td>
+			</tr>
+		</table>
+	>];
+	n5 -> n6[label="value",fontsize=12];
+	n4 -> n5[label="name",fontsize=12];
+	n1 -> n4[label="gender",fontsize=12];
+	n7[label=<
+		<table border='0' cellborder='1' cellspacing='0'>
+			<tr>
+				<td rowspan='2'>Person</td>
+			</tr>
+			<tr>
+				<td>age: 35</td>
+			</tr>
+		</table>
+	>];
+	n2[label=<
+		<table border='0' cellborder='1' cellspacing='0'>
+			<tr>
+				<td rowspan='3'>String</td>
+			</tr>
+			<tr>
+				<td>hash: 0</td>
+			</tr>
+			<tr>
+				<td>coder: 0</td>
+			</tr>
+		</table>
+	>];
+	n3[label=<
+		<table border='0' cellborder='1' cellspacing='0'>
+			<tr>
+				<td>65</td>
+				<td>108</td>
+				<td>98</td>
+				<td>101</td>
+				<td>114</td>
+				<td>116</td>
+			</tr>
+		</table>
+	>];
+	n2 -> n3[label="value",fontsize=12];
+	n7 -> n2[label="name",fontsize=12];
+	n4[label=<
+		<table border='0' cellborder='1' cellspacing='0'>
+			<tr>
+				<td rowspan='2'>Gender</td>
+			</tr>
+			<tr>
+				<td>ordinal: 0</td>
+			</tr>
+		</table>
+	>];
+	n5[label=<
+		<table border='0' cellborder='1' cellspacing='0'>
+			<tr>
+				<td rowspan='3'>String</td>
+			</tr>
+			<tr>
+				<td>hash: 2358797</td>
+			</tr>
+			<tr>
+				<td>coder: 0</td>
+			</tr>
+		</table>
+	>];
+	n6[label=<
+		<table border='0' cellborder='1' cellspacing='0'>
+			<tr>
+				<td>77</td>
+				<td>65</td>
+				<td>76</td>
+				<td>69</td>
+			</tr>
+		</table>
+	>];
+	n5 -> n6[label="value",fontsize=12];
+	n4 -> n5[label="name",fontsize=12];
+	n7 -> n4[label="gender",fontsize=12];
+	1 -> n1[label="",fontsize=12];
+	3 -> n7[label="",fontsize=12];
+}


### PR DESCRIPTION
HI @inponomarev,

I would like to know If I am going in the right direction for this issue.

`else if (!objectsId.containsKey(obj)) ` check in  `org.atpfivt.ljv.GraphBuilder#generateDotInternal`

will not add the node to the Graph if both are referring to the same Instance.

I had to find out the references of the original object in the method `org.atpfivt.ljv.GraphBuilder#generateDOT()`

I used a Pair Like data structure and processed the objects that refer to the same memory location.

Let me know your thoughts on this.

Here is the Diagram it created at the end.

![image](https://user-images.githubusercontent.com/4332242/111034015-07341c00-8414-11eb-9674-27dbe03f9bbb.png)

Thanks for your time. Awaiting your feedback :)
